### PR TITLE
Support subdomain URLs for webtasks when authenticating.

### DIFF
--- a/lib/auth0/auth0.js
+++ b/lib/auth0/auth0.js
@@ -198,6 +198,10 @@ function getRoutingInfo(req) {
         // Custom domain case: /{container}/{jtn}
         routingInfo.basePath = segments.splice(0, 3).join('/');
     }
+    else if (segments[1] === req.x_wt.jtn && req.headers.host.indexOf(req.x_wt.container + '.') === 0) {
+        // Webtask subdomain case: //{container}.us.webtask.io/{jtn}
+        routingInfo.basePath = segments.splice(0,2).join('/');
+    }
     else {
         return null;
     }


### PR DESCRIPTION
Subdomain URLs of the form https://{container}.us.webtask.io/{jtn}
can be used to invoke webtasks that authenticate using the .auth0()
package.